### PR TITLE
[user-docs] Improve markup in spreadsheet_export and add instructions for Thunderbird

### DIFF
--- a/user-docs/manual/04_reference/03_spreadsheet_export/index.rst
+++ b/user-docs/manual/04_reference/03_spreadsheet_export/index.rst
@@ -1,43 +1,69 @@
 .. _spreadsheet_export:
 
-Export CSV files from various spreadsheet applications
-******************************************************
+Export CSV files from various applications
+******************************************
+
+------------------------
+Spreadsheet applications
+------------------------
 
 .. More options: Microsoft Excel, Collabora Calc …?
 
-----------------
 LibreOffice Calc
 ----------------
 
-Choose **File** ➡ **Save as…**. In the **Filter** box, select **Text CSV**.
-(Optional) Set the field options for the Text CSV file. Select
-**Edit filter settings**. In the **Export of text files** dialog, select the
-options that you want. Click **OK** and then **Save**.
+Choose :menuselection:`File --> Save as…`. In the :guilabel:`Filter` box,
+select :guilabel:`Text CSV`. (Optional) Set the field options for the :file:`.csv`
+file. Select :guilabel:`Edit filter settings`. In the :guilabel:`Export of text files`
+dialog, select the options that you want. Click :guilabel:`OK` and then
+:guilabel:`Save`.
 
----------------
 Calligra Sheets
 ---------------
 
-Choose **File** ➡ **Export…** or **File** ➡ **Save As…**. The file saver dialog
-shows the current filename, currently probably with an *.ods* extension (the
-default in Calligra Sheets). Open the **File type** drop-down list and choose
-**CSV document**. The filename extension changes automatically to *.csv*. Then
-click on **Save**.
+Choose :menuselection:`File --> Export…` or :menuselection:`File --> Save As…`.
+The file saver dialog shows the current filename, currently probably with an
+:file:`.ods` extension (the default in :application:`Calligra Sheets`). Open the
+:guilabel:`File type` drop-down list and choose :guilabel:`CSV document`. The
+filename extension changes automatically to :file:`.csv`. Then click on
+:guilabel:`Save`.
 
--------------
 Google Sheets
 -------------
 
 .. Please verify this on ChromeOS; this is the behavior in the web interface
 
-Choose **File** ➡ **Download** ➡ **Comma Separated Values (CSV)**. The file
+Choose :menuselection:`File --> Download --> Comma Separated Values (CSV)`. The file
 will be downloaded automatically into your configured download folder. The
 original filename will be suffixed with * - SheetX* where *X* is the number of
 the sheet (should usually be irrelevant for our purposes).
 
---------
 Gnumeric
 --------
 
-Currently (2026-01), **gnumeric** seems to have no options to export *.csv*
-files. Please correct me if that is indeed possible.
+Currently (2026-01), :program:`Gnumeric` seems to have no options to export
+:file:`.csv` files. Please correct me if that is indeed possible.
+
+---------------------------------
+Mail Clients and PIM Applications
+---------------------------------
+
+Mozilla Thunderbird
+-------------------
+
+You can export an address book of your choice from :program:`Thunderbird`.
+Click on the address book icon in the vertical toolbar on the left or press
+:kbd:`Ctrl-2` to open the address book view. Right-click on one of your address books
+and choose :guilabel:`Export…`. A file chooser dialog will be opened. On top of
+the window you can enter a name and then choose a location for the to be exported
+file. With the drop-down menu in the bottom right corner, you can choose a file
+type; we need :guilabel:`Comma Separated (UTF-8)` for our purposes. Note, the
+exported :file:`.csv` file will contain many header entries which we don't need at
+all. It makes sense to open the exported file in a text editor (or even a spreadsheet
+application and re-export it as :file:`.csv` file) to remove the unneeded entries.
+
+Evolution
+---------
+
+KAddressBook
+------------


### PR DESCRIPTION
In gLabels 3.x, we had an option to use the Evolution address book as merge source. Not needed at all, as far as you don't use Evolution anyway – we can't support all address books all around. But I think we can add instructions for how to export `.csv` files from mail clients and PIM apps. I started with writing something about Thunderbird; next, I will have a look at the workflow in Evolution and KAddressBook. I also improved the markup to match the markup in the `.rst` files already revised by you. 